### PR TITLE
17-Date.cpp in examples seems to have some typos

### DIFF
--- a/examples/17-Date.cpp
+++ b/examples/17-Date.cpp
@@ -1,26 +1,26 @@
 #include <nodepp/nodepp.h>
-#include <nodepp/data.h>
+#include <nodepp/date.h>
 
 using namespace nodepp;
 
 void onMain(){
 
-    console::log( "now->", data::now() );
+    console::log( "now->", date::now() );
 
     console::log(" -- -- ");
 
-    console::log( "day->", data::day() );
+    console::log( "day->", date::day() );
 
-    console::log( "year->", data::year() );
+    console::log( "year->", date::year() );
 
-    console::log( "month->", data::month() );
+    console::log( "month->", date::month() );
 
     console::log(" -- -- ");
 
-    console::log( "hours->", data::hours() );
+    console::log( "hours->", date::hour() );
 
-    console::log( "minutes->", data::minutes() );
+    console::log( "minutes->", date::minute() );
 
-    console::log( "seconds->", data::seconds() );
+    console::log( "seconds->", date::second() );
 
 }


### PR DESCRIPTION
There seems to be some typo in 17-Date.cpp
```cpp
#include <nodepp/data.h>
...
data::hours()
...
data::seconds()
...
data::minutes()
```

Changed to 
```cpp
#include <nodepp/date.h>
...
data::hour()
...
data::minute()
...
data::second()
```
Now it works properly