### PR TITLE
Typo on types.h

### DIFF
--- a/include/nodepp/type.h
+++ b/include/nodepp/type.h
@@ -353,7 +353,7 @@ namespace nodepp { namespace type {
         static constexpr bool value = __is_base_of( T, V );
     };
 
-    template<typename T> struct is_polimorfic {
+    template<typename T> struct is_polymorphic {
         static constexpr bool value = __is_polymorphic(T);
     };
 


### PR DESCRIPTION
I was just taking a look at types.h and found a small typo

Is polimorfic -> is polimorphic